### PR TITLE
Add filter to control exclude page ids

### DIFF
--- a/classes/subway-page-redirect.php
+++ b/classes/subway-page-redirect.php
@@ -108,6 +108,7 @@ final class PageRedirect
         if (! is_user_logged_in() ) {
 
             if ($current_page_id !== $login_page_id ) {
+                $excluded_page = apply_filters( 'subway_excluded_page', $excluded_page, $current_page_id );
 
                 if (! in_array($current_page_id, $excluded_page, true) ) {
 


### PR DESCRIPTION
Use example: allow unlogged users to access all blog posts. Thanks to such filter, it's possible to check if current post is of type 'post' and then exclude it from the redirect process.