### PR TITLE
bugfix, fixes #54

### DIFF
--- a/classes/subway-metabox.php
+++ b/classes/subway-metabox.php
@@ -249,7 +249,9 @@ final class Metabox {
 					}
 				}
 				if ( 'private' === $post_visibility ) {
-					unset( $public_posts[ array_search( $post_id, $public_posts ) ] );
+					if ( in_array( $post_id, $public_posts ) ) {
+						unset( $public_posts[ array_search( $post_id, $public_posts ) ] );
+					}
 				}
 			}
 		}


### PR DESCRIPTION
When you

```php
unset( $public_posts[ array_search( $post_id, $public_posts ) ] );
```
and `$post_id` is not in `$public_posts`, it will remove the first element in the list, - which means that when changing a private post, that was not public, it will remove another public post from the list of public posts.

This bugfix makes sure that `$post_id` is in the list of public posts, before trying to remove it, thus fixing #54 

Please include this in a release soon :)